### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 
-* @ToshiWakayama-KDDI
+* @ToshiWakayama-KDDI @fernandopradocabrillo @GillesInnov35


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

* add two codeowners 

#### Which issue(s) this PR fixes:

NA

#### Special notes for reviewers:

It was agreed to add three codeowners in addtion to ToshiWakayama-KDDI at the Oct-31st meeting, but Admin recommended to keep the sum up to three, so, this PR was created to add two codeowners fernandopradocabrillo and GillesInnov35 (not add tcchiba this time).

#### Changelog input


#### Additional documentation 

