### PR TITLE
Remove countryMatchScore property

### DIFF
--- a/code/API_definitions/kyc-match.yaml
+++ b/code/API_definitions/kyc-match.yaml
@@ -49,7 +49,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.2.0-rc.1
+  version: wip
 
   x-camara-commonalities: 0.4.0
 
@@ -383,8 +383,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/MatchResult'
             - description: Indicates whether the country of the customer's address matches with the one on the Operator's system.
-        countryMatchScore:
-          $ref: '#/components/schemas/MatchScoreResult'
         houseNumberExtensionMatch:
           allOf:
             - $ref: '#/components/schemas/MatchResult'


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction

#### What this PR does / why we need it:
Since Country property is now in ISO 3166 alpha-2 codification, so it doesn't make sense to have an score for this property.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #134 

#### Special notes for reviewers:
yaml version has been set to wip in case we have to include more changes before the final release. At that moment, the release PR will contain the final version change.
