### PR TITLE
KYC-Fill-In: define scopes

### DIFF
--- a/code/API_definitions/kyc-fill-in.yaml
+++ b/code/API_definitions/kyc-fill-in.yaml
@@ -79,8 +79,46 @@ paths:
 
       security:
         - openId:
-          - kyc-fill-in:fill-in
-
+          - kyc-fill-in:fill-in kyc-fill-in:phoneNumber
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:idDocument
+        - openId:
+          - kyc-fill-in:fill-in name
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:givenName
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:familyName
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:nameKanaHankaku
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:nameKanaZenkaku
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:middleNames
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:familyNameAtBirth
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:address
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:streetName
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:streetNumber
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:postalCode
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:region
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:locality
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:country
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:houseNumberExtension
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:birthdate
+        - openId:
+          - kyc-fill-in:fill-in email
+        - openId:
+          - kyc-fill-in:fill-in kyc-fill-in:gender
+        
       parameters:
         - $ref: '#/components/parameters/x-correlator'
 

--- a/code/API_definitions/kyc-fill-in.yaml
+++ b/code/API_definitions/kyc-fill-in.yaml
@@ -79,45 +79,45 @@ paths:
 
       security:
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:phoneNumber
+          - kyc-fill-in:phoneNumber
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:idDocument
+          - kyc-fill-in:idDocument
         - openId:
-          - kyc-fill-in:fill-in name
+          - kyc-fill-in:name
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:givenName
+          - kyc-fill-in:givenName
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:familyName
+          - kyc-fill-in:familyName
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:nameKanaHankaku
+          - kyc-fill-in:nameKanaHankaku
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:nameKanaZenkaku
+          - kyc-fill-in:nameKanaZenkaku
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:middleNames
+          - kyc-fill-in:middleNames
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:familyNameAtBirth
+          - kyc-fill-in:familyNameAtBirth
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:address
+          - kyc-fill-in:address
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:streetName
+          - kyc-fill-in:streetName
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:streetNumber
+          - kyc-fill-in:streetNumber
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:postalCode
+          - kyc-fill-in:postalCode
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:region
+          - kyc-fill-in:region
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:locality
+          - kyc-fill-in:locality
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:country
+          - kyc-fill-in:country
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:houseNumberExtension
+          - kyc-fill-in:houseNumberExtension
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:birthdate
+          - kyc-fill-in:birthdate
         - openId:
           - kyc-fill-in:fill-in email
         - openId:
-          - kyc-fill-in:fill-in kyc-fill-in:gender
+          - kyc-fill-in:gender
         
       parameters:
         - $ref: '#/components/parameters/x-correlator'

--- a/code/API_definitions/kyc-fill-in.yaml
+++ b/code/API_definitions/kyc-fill-in.yaml
@@ -79,6 +79,8 @@ paths:
 
       security:
         - openId:
+          - kyc-fill-in:all
+        - openId:
           - kyc-fill-in:phoneNumber
         - openId:
           - kyc-fill-in:idDocument

--- a/code/API_definitions/kyc-fill-in.yaml
+++ b/code/API_definitions/kyc-fill-in.yaml
@@ -79,7 +79,7 @@ paths:
 
       security:
         - openId:
-          - kyc-fill-in:all
+          - kyc-fill-in:set-all
         - openId:
           - kyc-fill-in:phoneNumber
         - openId:

--- a/code/API_definitions/kyc-fill-in.yaml
+++ b/code/API_definitions/kyc-fill-in.yaml
@@ -115,7 +115,7 @@ paths:
         - openId:
           - kyc-fill-in:birthdate
         - openId:
-          - kyc-fill-in:fill-in email
+          - kyc-fill-in:email
         - openId:
           - kyc-fill-in:gender
         

--- a/code/API_definitions/kyc-fill-in.yaml
+++ b/code/API_definitions/kyc-fill-in.yaml
@@ -33,6 +33,10 @@ info:
       * when calling this API, the client of a 3rd party / enterprise customer put its 3rd party identity (only) in the request body
       * then, API provider / MNO will provide information (attributes) which the 3rd party / enterprise customer is allowed to receive by the contract.
 
+    ### Special Scopes
+
+    This API uses the following special scope kyc-fill-in:set-all which means that the API provider returns an API response as if all these scopes were specified in the scope value in the request:
+    `kyc-fill-in:phoneNumber kyc-fill-in:idDocument kyc-fill-in:name kyc-fill-in:givenName kyc-fill-in:familyName kyc-fill-in:nameKanaHankaku kyc-fill-in:nameKanaZenkaku kyc-fill-in:middleNames kyc-fill-in:familyNameAtBirth kyc-fill-in:address kyc-fill-in:streetName kyc-fill-in:streetNumber kyc-fill-in:postalCode kyc-fill-in:region kyc-fill-in:locality kyc-fill-in:country kyc-fill-in:houseNumberExtension kyc-fill-in:birthdate kyc-fill-in:email kyc-fill-in:gender`
 
     ## Resources and Operations overview
 


### PR DESCRIPTION
The current KYC Fill-In API does not fulfill the [GDPR principle of data minimization.](https://gdpr-info.eu/art-5-gdpr/#:~:text=adequate%2C%20relevant%20and%20limited%20to%20what%20is%20necessary%20in%20relation%20to%20the%20purposes%20for%20which%20they%20are%20processed%20(%E2%80%98data%20minimisation%E2%80%99))

#### What type of PR is this?

* correction

#### What this PR does / why we need it:
This PR defines the scopes that the API consumer can use when sending an [OIDC authentication request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) or an [CIBA authentication request](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.7.1).

Removed 2024-10-29: references to standard claims defined in OIDC. I think it might be a separate discussion why CAMARA KYC uses e.g. givenName and not given_name. As defined in OIDC standard claims.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #90 

#### Special notes for reviewers:
OpenAPI specification: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-requirement-object

> If the security scheme is of type "oauth2" or "openIdConnect", then the value is a list of scope names required for the execution

Which means that the API Consumer can request using `scope="openid kyc-fill-in:fill-in kyc-fill-in:phoneNumber name".
The access token would then have the scopes associated with it and the API producer will then find this association and the security requirement would be fulfilled. Then the API producer can go through the list of associated scopes and can add the requested attributes to the KYC Fill-In response.


