### PR TITLE
Correct name of middleNames Match Score attribute in kyc-match yaml file

### DIFF
--- a/code/API_definitions/kyc-match.yaml
+++ b/code/API_definitions/kyc-match.yaml
@@ -349,7 +349,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/MatchResult'
             - description: Indicates whether the middle names of the customer matches with the one on the Operator's system.
-        middleNamesScore:
+        middleNamesMatchScore:
           $ref: '#/components/schemas/MatchScoreResult'
         familyNameAtBirthMatch:
           allOf:


### PR DESCRIPTION
Correct name of middleNames Match Score attribute


#### What type of PR is this?

Add one of the following kinds:
* correction

#### What this PR does / why we need it:
Correct name of middleNames Match Score response attribute. 
Replace middleNamesScore by **middleNamesMatchScore**

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #https://github.com/camaraproject/KnowYourCustomer/issues/161

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

