### PR TITLE
Updated Age Verification proposal aligned with Spring25

### DIFF
--- a/code/API_definitions/kyc-age-verification.yaml
+++ b/code/API_definitions/kyc-age-verification.yaml
@@ -11,7 +11,7 @@ info:
 
     The API defines one service endpoint:
 
-    - `POST /ageverify`
+    - `POST /verify`
 
       Takes the network subscription identifier (e.g. the mobile phone number for a mobile network subscriber) and checks if the age of the subscriber is older than the age threshold in the request.
       Additionally, as optional function, provides (1) if age check is done against another form of official identification or not (verifiedStatus), (2) an overall score of how certain is the response using both information provided in the request and information that the Operator holds(identityMatchScore), (3) an indicator on whether the subscription has any kind of content lock (contentLock) and (4) an indicator on whether the subscription has any kind of parental control activated (parentalControl).
@@ -23,7 +23,7 @@ info:
     - `phoneNumber`: The network subscription identifier (i.e. the phone number of the subscriber). [Required only in case a 2-legged flow has been agreed between API Provider and API Consumer following CAMARA directives; otherwise, phoneNumber must not be included]
     - `ageThreshold`: The age threshold from which the age of the user must be compared. [Required]
     - any of `idDocument`, `name`, `givenName`, `familyName`, `middleNames`, `familyNameAtBirth`, `birthdate`, `email`; additional subscriber's information to be checked in order to confirm that the subscriber is the contract's owner [Optional]
-    - `contentLock` and `parentLock`: These two flags allow the API Client to indicate that the corresponding response properties should be returned. [Optional]
+    - `includeContentLock` and `includeParentalControl`: These two flags allow the API Client to indicate that the corresponding response properties `contentLock` and `parentalControl` should be returned. Its implementation is optional for the API Provider, so in such cases, these parameters will be ignored. [Optional]
 
 
     ## Outputs
@@ -37,7 +37,7 @@ info:
     
     ## Errors
 
-    - If the authentication token is not valid, a `401 UNAUTHENTICATED` error is returned
+    - If the authentication access token is not valid, a `401 UNAUTHENTICATED` error is returned
     - If the API call contains a formatting or other any other syntactic error, a `400 INVALID_ARGUMENT` error is returned.
     - If the network subscription cannot be identified from the provided parameters (e.g. the subscription identifier is not associated with any customer of the CSP), a `404 IDENTIFIER_NOT_FOUND` error is returned.
     - If the API consumer has a valid access token but is not authorised to request an age verification for the specified network subscription, then a `403 PERMISSION_DENIED` error is returned.
@@ -97,9 +97,9 @@ paths:
       description: |
         Verify that the age of the subscriber associated with a phone number is equal to or greater than the specified age threshold value.
 
-        As it is possible that the person holding the contract and the person using the line may not be the same, the endpoint also admits a list of optional properties to be included in the request to improve the identification. The response may optionally include the `identityMatchScore` property with a value that indicates how certain it is that the information returned relates to the person that the API Client is requesting. To increase the reliability of the information returned, the operator may include in the response the `verifiedStatus` property, indicating whether the identity information in its possession has been verified against an official source.
+        As it is possible that the person holding the contract and the end-user of the subscription may not be the same, the endpoint also admits a list of optional properties to be included in the request to improve the identification. The response may optionally include the `identityMatchScore` property with a value that indicates how certain it is that the information returned relates to the person that the API Client is requesting. To increase the reliability of the information returned, the API Provider may include in the response the `verifiedStatus` property, indicating whether the identity information in its possession has been verified against an identification document legally accepted as an age verification document.
 
-        The response may also include `contentLock` and `parentalControl` properties to indicate if the line has any kind of content filtering enabled.
+        If the API Client indicates request properties `includeContentLock` or `includeParentalControl` with value `true` and the API Provider implements this functionality, then the response will also include `contentLock` and `parentalControl` properties to indicate if the subscription has any kind of content filtering enabled. On the other hand, if the request properties are not included or the API Client specifies value `false`, then the response properties will not be returned. If the API Provider doesn't implement this functionality, request properties will be ignored and response properties won't be returned in any case.
       operationId: verifyAge
       security:
         - openId:
@@ -125,8 +125,8 @@ paths:
                   familyNameAtBirth: YYYY
                   birthdate: '1978-08-22'
                   email: "federicaSanchez.Arjona@example.com"
-                  contentLock: true
-                  parentalControl: true
+                  includeContentLock: true
+                  includeParentalControl: true
               Three-Legged Access Token Example:
                 value:
                   ageThreshold: 18
@@ -138,8 +138,8 @@ paths:
                   familyNameAtBirth: YYYY
                   birthdate: '1978-08-22'
                   email: "federicaSanchez.Arjona@gmail.com"
-                  contentLock: true
-                  parentalControl: true
+                  includeContentLock: true
+                  includeParentalControl: true
 
       responses:
         '200':
@@ -208,50 +208,85 @@ components:
         - ageThreshold
       properties:
         ageThreshold:
-          type: "integer"
-          minimum: 0
-          maximum: 120
-          description: The age to be verified. The indicated range is a global definition of maximum and minimum values allowed to be requested. It is important to note that this range might be more restrictive in some implementations due to local regulations of a country i.e. A country does not allow to request for an age under 18. This limitation must be informed during the onboarding process.
+          $ref: "#/components/schemas/AgeThreshold"
         phoneNumber:
-          description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
-          type: string
-          pattern: '^\+[1-9][0-9]{4,14}$'
-          example: "+123456789"
+          $ref: "#/components/schemas/PhoneNumber"
         idDocument:
-          type: "string"
-          description: Id number associated to the official identity document in the country. It may contain alphanumeric characters.
+          $ref: "#/components/schemas/IdDocument"
         name:
-          type: "string"
-          description: Complete name of the customer, usually composed of first/given name and last/family/sur- name in a country.  Depending on the country, the order of first/give name and last/family/sur- name varies, and middle name could be included.  It can use givenName, middleNames, familyName and/or familyNameAtBirth. For example, in ESP, name+familyName; in NLD, it can be name+middleNames+familyName or name+middleNames+familyNameAtBirth, etc.
+          $ref: "#/components/schemas/Name"
         givenName:
-          type: "string"
-          description: First/given name or compound first/given name of the customer.
+          $ref: "#/components/schemas/GivenName"
         familyName:
-          type: "string"
-          description: Last name, family name, or surname of the customer.
+          $ref: "#/components/schemas/FamilyName"
         middleNames:
-          type: "string"
-          description: Middle name/s of the customer.
+          $ref: "#/components/schemas/MiddleNames"
         familyNameAtBirth:
-          type: "string"
-          description: Last/family/sur- name at birth of the customer.
+          $ref: "#/components/schemas/FamilyNameAtBirth"
         birthdate:
-          type: string
-          format: date
-          description: The birthdate of the customer, in RFC 3339 / ISO 8601 calendar date format (YYYY-MM-DD).
+          $ref: "#/components/schemas/Birthdate"
         email:
-          type: string
-          format: email
-          description: Email address of the customer in the RFC specified format (local-part@domain).
-        contentLock:
-          type: boolean
-          default: false
-          description: If this parameter is included in the request with value `true`, the response property `contentLock` will be returned. If it is not included or its value is `false`, the response property will not be returned.
-        parentalControl:
-          type: boolean
-          default: false
-          description: If this parameter is included in the request with value `true`, the response property `parentalControl` will be returned. If it is not included or its value is `false`, the response property will not be returned.
+          $ref: "#/components/schemas/Email"
+        includeContentLock:
+          $ref: "#/components/schemas/IncludeContentLock"
+        includeParentalControl:
+          $ref: "#/components/schemas/IncludeParentalControl"
 
+    AgeThreshold:
+      type: "integer"
+      minimum: 0
+      maximum: 120
+      description: The age to be verified. The indicated range is a global definition of maximum and minimum values allowed to be requested. It is important to note that this range might be more restrictive in some implementations due to local regulations of a country i.e. A country does not allow to request for an age under 18. This limitation must be informed during the onboarding process.
+
+    PhoneNumber:
+      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
+      type: string
+      pattern: '^\+[1-9][0-9]{4,14}$'
+      example: "+123456789"
+
+    IdDocument:
+      type: "string"
+      description: Id number associated to the official identity document in the country. It may contain alphanumeric characters.
+
+    Name:
+      type: "string"
+      description: Complete name of the customer, usually composed of first/given name and last/family/sur- name in a country.  Depending on the country, the order of first/give name and last/family/sur- name varies, and middle name could be included.  It can use givenName, middleNames, familyName and/or familyNameAtBirth. For example, in ESP, name+familyName; in NLD, it can be name+middleNames+familyName or name+middleNames+familyNameAtBirth, etc.
+
+    GivenName:
+      type: "string"
+      description: First/given name or compound first/given name of the customer.
+
+    FamilyName:
+      type: "string"
+      description: Last name, family name, or surname of the customer.
+
+    MiddleNames:
+      type: "string"
+      description: Middle name/s of the customer.
+
+    FamilyNameAtBirth:
+      type: "string"
+      description: Last/family/sur- name at birth of the customer.
+
+    Birthdate:
+      type: string
+      format: date
+      description: The birthdate of the customer, in RFC 3339 / ISO 8601 calendar date format (YYYY-MM-DD).
+
+    Email:
+      type: string
+      format: email
+      description: Email address of the customer in the RFC specified format (local-part@domain).
+
+    IncludeContentLock:
+      type: boolean
+      default: false
+      description: If this parameter is included in the request with value `true`, the response property `contentLock` will be returned. If it is not included or its value is `false`, the response property will not be returned.
+
+    IncludeParentalControl:
+      type: boolean
+      default: false
+      description: If this parameter is included in the request with value `true`, the response property `parentalControl` will be returned. If it is not included or its value is `false`, the response property will not be returned.
 
     VerifyResponseBody:
       type: "object"
@@ -272,7 +307,7 @@ components:
 
     AgeCheck:
       type: "string"
-      description: Indicate `"true"` when the age of the user is the same age or older than the age threshold (age >= age threshold), and `"false"` if not (age < age threshold). If the Operator doesn't have enough information to perform the validation, a `not_available` can be returned. 
+      description: Indicate `"true"` when the age of the user is the same age or older than the age threshold (age >= age threshold), and `"false"` if not (age < age threshold). If the API Provider doesn't have enough information to perform the validation, a `not_available` can be returned. 
       enum:
         - 'true'
         - 'false'
@@ -280,13 +315,13 @@ components:
 
     VerifiedStatus:
       type: "boolean"
-      description: Indicates if the information provided was checked against another form of official identification held by the Operator.
+      description: Indicate `true` if the information provided has been compared against information based on an identification document legally accepted as an age verification document, otherwise indicate `false`.
 
     IdentityMatchScore:
       type: "integer"
       minimum: 0
       maximum: 100
-      description: The overall score of identity information available in the Operator, information either provided in the request body comparing it to the one that the Operator holds or directly using internal Operator's information. It is optional for the Operator to return the Identity match score.
+      description: The overall score of identity information available in the API Provider, information either provided in the request body comparing it to the one that the API Provider holds or directly using internal API Provider's information. It is optional for the API Provider to return the Identity match score.
 
     ContentLock:
       type: "string"
@@ -298,7 +333,7 @@ components:
     
     ParentalControl:
       type: "string"
-      description: Indicate `"true"` if the subscription associated with the phone number has any kind of parental control activated. and `"false"` if not. If the information is not available the value `not_available` can be returned.
+      description: Indicate `"true"` if the subscription associated with the phone number has any kind of parental control activated and `"false"` if not. If the information is not available the value `not_available` can be returned.
       enum:
         - 'true'
         - 'false'


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature


#### What this PR does / why we need it:
This PR include all the changes and suggestions that haven been made these past months regarding Age Verification in PR #50.
It is a clean version with errors and descriptions aligned with the latest version of Commonalities for Spring25 meta release.

Additionally, it contains a proposal to include two new fields in the response: `contentLock` and `parentalControl`. Both fields come from the feedback of our partners in the UK.

This PR is ment to replace PR #50 as it seems easier to work on a updated fresh copy.

Please leave any comments or changes you feel appropriate.

Thanks!
