### PR TITLE
Add KYC-Fill-In examples for consent collection, access token requests and API use

### DIFF
--- a/documentation/API_documentation/KYC-Fill-in.md
+++ b/documentation/API_documentation/KYC-Fill-in.md
@@ -38,4 +38,142 @@ The API provides the following endpoint:
 
 * An endpoint to request information related to an end user against the acount data bound to their phone number.
 
+## Examples
 
+As always examples are non-normative.
+
+### Get user consent for a set of scopes and purpose
+
+Example OIDC authorization code flow request requesting consent for all user-attributes and purpose dpv:FraudPreventionAndDetection.
+This consent  collection using OIDC authorization code flow can happen at any time the API consumer seems fit e.g. a user account creation time at the API consumer's website or when the API consumer's mobile app is installed on the end user's mobile device.
+
+```
+GET /authorize?
+    response_type=code
+    &prompt=consent
+    &scope=openid%20dpv%3AFraudPreventionAndDetection%20kyc-fill-in%3Aset-all
+    &client_id=s6BhdRkqt3
+    &state=af0ifjsldkj
+    &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb HTTP/1.1
+Host: authserver.example.com
+```
+
+### Get an access token for a set of scopes and purpose
+
+#### Getting the code
+
+Assuming consent was granted and not revoked or is not needed, an access token is returned
+
+```
+GET /authorize?
+    response_type=code
+    &prompt=none
+    &scope=openid%20dpv%3AFraudPreventionAndDetection%20kyc-fill-in%3Aset-all
+    &client_id=s6BhdRkqt3
+    &state=af0ifjsldkj
+    &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb HTTP/1.1
+Host: authserver.example.com
+```
+
+Error Response
+
+If consent is needed, then the authorization server returns an [error](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) 
+
+```
+HTTP/1.1 302 Found
+  Location: https://client.example.org/cb?
+    error=consent_required
+    &state=af0ifjsldkj
+```
+
+Sucessful Response:
+
+```
+HTTP/1.1 302 Found
+  Location: https://client.example.org/cb?
+    code=SplxlOBeZQQYbYS6WxSbIA
+    &state=af0ifjsldkj
+```
+
+#### Token Request:
+
+In CAMARA client authentication MUST be using private_key_jwt
+
+```
+POST /token HTTP/1.1
+
+Host: server.example.com 
+Content-Type: application/x-www-form-urlencoded 
+
+grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA
+    &redirect_uri=https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb
+    &client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
+    &client_assertion=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3Mi......
+```
+
+#### Successful Token Response
+
+```
+HTTP/1.1 200 OK
+  Content-Type: application/json
+  Cache-Control: no-store
+
+  {
+   "access_token": "SlAV32hkKG",
+   "token_type": "Bearer",
+   "refresh_token": "8xLOxBtZp8",
+   "expires_in": 3600,
+   "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFlOWdkazcifQ.ewogImlzc
+     yI6ICJodHRwOi8vc2VydmVyLmV4YW1wbGUuY29tIiwKICJzdWIiOiAiMjQ4Mjg5
+     NzYxMDAxIiwKICJhdWQiOiAiczZCaGRSa3F0MyIsCiAibm9uY2UiOiAibi0wUzZ
+     fV3pBMk1qIiwKICJleHAiOiAxMzExMjgxOTcwLAogImlhdCI6IDEzMTEyODA5Nz
+     AKfQ.ggW8hZ1EuVLuxNuuIJKX_V8a_OMXzR0EHR9R6jgdqrOOF4daGU96Sr_P6q
+     Jp6IcmD3HP99Obi1PRs-cwh3LO-p146waJ8IhehcwL7F09JdijmBqkvPeB2T9CJ
+     NqeGpe-gccMg4vfKjkM8FcGvnzZUN4_KSP0aAp1tOJ1zZwgjxqGByKHiOtX7Tpd
+     QyHE5lcMiKPXfEIQILVq0pc_E2DzL7emopWoaoZTF_m0_N0YzFC6g6EJbOEoRoS
+     K5hoDalrcvRYLSrQAZZKflyuVCyixEoV9GfNQC3_osjzw2PAithfubEEBLuVVk4
+     XUVrWOLrLl0nx7RkKU8NXNHq-rvKMzqg"
+  }
+```
+
+### Using an access token at the KYC-Fill-In API endpoint
+
+API request:
+
+The access token is associated with a subject identifier and all the scoces from the authorization request.
+The subject identifier can be a MSISDN e.g. "+34629255833" or an MNO-internal user identifier or user account number e.g. `ba7315d5-04e2-4701-b3db-27824d50a97e`.
+Because the access token is created by the MNO's authorization server and consumed by the MNO's resource server any subject identifier can be used.
+
+```
+GET /fill-in
+Authorization: Bearer SlAV32hkKG
+Host: resourceserver.example.com
+```
+
+API response:
+
+```
+HTTP/1.1 200 OK
+  Content-Type: application/json
+  Cache-Control: no-store
+
+{
+  "phoneNumber": "+34629255833",
+  "idDocument": "66666666q",
+  "name": "Federica Sanchez Arjona",
+  "givenName": "Federica",
+  "familyName": "Sanchez Arjona",
+  "nameKanaHankaku": "federica",
+  "nameKanaZenkaku": "Ｆｅｄｅｒｉｃａ",
+  "middleNames": "Sanchez",
+  "familyNameAtBirth": "YYYY",
+  "address": "Tokyo-to Chiyoda-ku Iidabashi 3-10-10",
+  "streetName": "Nicolas Salmeron",
+  "streetNumber": "4",
+  "postalCode": "1028460",
+  "region": "Tokyo",
+  "locality": "ZZZZ",
+  "country": "JP",
+  "houseNumberExtension": "36"
+}
+```


### PR DESCRIPTION
#### What type of PR is this?
* documentation

#### What this PR does / why we need it:

This PR shows:
- how user consent can be requested using OIDC authorization code flow
- the use of kyc-fill-in:set-all when requesting an OIDC code
- explains that the subject identifier for the API is associated with the access token
- explains that the scopes for the API is associated with the access token

No extra phoneNumber request parameter is needed when using 3-legged / front-end flow.
Using an extra phoneNumber parameter in the API request should be restricted to 2-legged flow.


