### PR TITLE
[KYC Match]: Minor correction. Removing idDocumentMatchScore from test definition.

### DIFF
--- a/code/Test_definitions/kyc-match.feature
+++ b/code/Test_definitions/kyc-match.feature
@@ -80,7 +80,6 @@ Feature: CAMARA Know Your Customer Match API, v0.3.0 - Operation KYC_Match
 
         Examples:
             | request_property_path     | response_property_path        | response_score_property_path  |
-            | $.idDocument              | $.idDocumentMatch             | $.idDocumentMatchScore        |
             | $.name                    | $.nameMatch                   | $.nameMatchScore              |
             | $.givenName               | $.givenNameMatch              | $.givenNameMatchScore         |
             | $.familyName              | $.familyNameMatch             | $.familyNameMatchScore        |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* cleanup

#### What this PR does / why we need it:

Minor correction. Removing `idDocumentMatchScore` as an example response_score_property_path. The field does not exist in the main KYC API spec.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Fixes #216

#### Changelog input

```
Update kyc-match.feature to remove an example value
```


